### PR TITLE
fix(add-recipe): align UI with Figma design and increase instructions…

### DIFF
--- a/frontend/src/features/recipe-create/ui/RecipeEditorForm.tsx
+++ b/frontend/src/features/recipe-create/ui/RecipeEditorForm.tsx
@@ -203,8 +203,12 @@ export const RecipeEditorForm = ({
           Label: #bfbebe, ExtraBold, 24px desktop / 16px mobile, uppercase
           Input: underline only, placeholder "Enter a description of the dish"
           Counter: 0/200 inline right — Figma node 22:741
+          Note: no separate Description field — not present in Figma design
         */}
         <div className={styles.groupName}>
+          <label className={styles.labelName} htmlFor="recipe-name">
+            The name of the recipe
+          </label>
           <div className={styles.inputWithCounter}>
             <div className={styles.inputCounterField}>
               <Input
@@ -213,7 +217,7 @@ export const RecipeEditorForm = ({
                 value={formik.values.name}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
-                placeholder="The name of the recipe"
+                placeholder="Enter a description of the dish"
                 hasError={Boolean(formik.touched.name && formik.errors.name)}
                 disabled={isSubmitting}
                 maxLength={200}
@@ -223,28 +227,6 @@ export const RecipeEditorForm = ({
             <span className={styles.counter}>{formik.values.name.length}/200</span>
           </div>
           {formik.touched.name && formik.errors.name && <FormErrorMessage>{formik.errors.name}</FormErrorMessage>}
-        </div>
-
-        {/* Description */}
-        <div className={styles.group}>
-          <label className={styles.label} htmlFor="recipe-description">
-            Description
-          </label>
-          <TextArea
-            id="recipe-description"
-            name="description"
-            value={formik.values.description}
-            onChange={formik.handleChange}
-            onBlur={formik.handleBlur}
-            placeholder="Enter a description of the dish"
-            hasError={Boolean(formik.touched.description && formik.errors.description)}
-            disabled={isSubmitting}
-            rows={4}
-            maxLength={3000}
-          />
-          {formik.touched.description && formik.errors.description && (
-            <FormErrorMessage>{formik.errors.description}</FormErrorMessage>
-          )}
         </div>
 
         {/* Category + Cooking time — side by side per Figma */}

--- a/frontend/src/features/recipe-create/validation/recipeEditorValidation.ts
+++ b/frontend/src/features/recipe-create/validation/recipeEditorValidation.ts
@@ -41,12 +41,11 @@ export const recipeEditorSchema: Yup.ObjectSchema<RecipeEditorFormValues> = Yup.
     .max(200, "Name is too long")
     .required("Name is required"),
   description: Yup.string()
-    // Figma shows 0/200 counter on description field
     .min(100, "Description must be at least 100 characters")
     .max(500, "Description must be less than 500 characters")
     .required("Description is required"),
   instructions: Yup.string()
-    .min(200, "Instructions must be at least 200 characters")
+    .min(10, "Instructions must be at least 10 characters")
     // Updated from 1000 to 3000 per task requirement
     .max(3000, "Instructions must be less than 3000 characters")
     .required("Instructions are required"),


### PR DESCRIPTION
… limit to 3000

- Remove Description field — not present in Figma design (node 44:1557)
- Restore label 'The name of the recipe' with correct Figma styles
- Fix name input placeholder to 'Enter a description of the dish'
- Increase instructions maxLength from 1000 to 3000
- Fix instructions Yup min from 200 to 10 characters