### PR TITLE
fix(category): add illustrated empty state for filtered no-results

### DIFF
--- a/frontend/src/pages/category/CategoryEmptyState.module.css
+++ b/frontend/src/pages/category/CategoryEmptyState.module.css
@@ -1,0 +1,71 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--fd-space-40) var(--fd-space-16);
+  min-height: 360px;
+  gap: var(--fd-space-16);
+}
+
+.illustration {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background-color: var(--fd-bg-muted);
+  color: var(--fd-text-muted);
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--fd-font-family-base);
+  font-weight: var(--fd-font-weight-extrabold);
+  font-size: var(--fd-type-h3-mobile-size);
+  line-height: var(--fd-line-height-28);
+  letter-spacing: var(--fd-letter-spacing-tight);
+  color: var(--fd-text-primary);
+  text-transform: uppercase;
+}
+
+.subtitle {
+  margin: 0;
+  font-family: var(--fd-font-family-base);
+  font-weight: var(--fd-font-weight-medium);
+  font-size: var(--fd-type-main-mobile-size);
+  line-height: var(--fd-type-main-mobile-height);
+  color: var(--fd-text-muted);
+  max-width: 300px;
+}
+
+@media (min-width: 768px) {
+  .container {
+    padding: var(--fd-space-80) var(--fd-space-24);
+    gap: var(--fd-space-20);
+  }
+
+  .illustration {
+    width: 140px;
+    height: 140px;
+  }
+
+  .illustration svg {
+    width: 112px;
+    height: 112px;
+  }
+
+  .title {
+    font-size: var(--fd-type-h3-desktop-size);
+    line-height: var(--fd-line-height-28);
+  }
+
+  .subtitle {
+    font-size: var(--fd-type-main-desktop-size);
+    line-height: var(--fd-type-main-desktop-height);
+    max-width: 400px;
+  }
+}

--- a/frontend/src/pages/category/CategoryEmptyState.tsx
+++ b/frontend/src/pages/category/CategoryEmptyState.tsx
@@ -1,0 +1,44 @@
+import styles from "./CategoryEmptyState.module.css";
+
+export const CategoryEmptyState = () => (
+  <div className={styles.container}>
+    <div className={styles.illustration}>
+      <svg
+        width="96"
+        height="96"
+        viewBox="0 0 96 96"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        {/* Fork */}
+        <line x1="26" y1="12" x2="26" y2="84" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+        <path
+          d="M19 12 L19 34 Q19 41 26 41 Q33 41 33 34 L33 12"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {/* Knife */}
+        <line x1="70" y1="12" x2="70" y2="84" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+        <path
+          d="M70 12 Q82 20 82 34 L70 39"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {/* Plate outer */}
+        <circle cx="48" cy="52" r="24" stroke="currentColor" strokeWidth="3" />
+        {/* Plate inner ring */}
+        <circle cx="48" cy="52" r="16" stroke="currentColor" strokeWidth="1.5" strokeDasharray="4 4" />
+      </svg>
+    </div>
+
+    <h2 className={styles.title}>No recipes found</h2>
+    <p className={styles.subtitle}>
+      Try adjusting or clearing your filters to discover more delicious recipes.
+    </p>
+  </div>
+);

--- a/frontend/src/pages/category/CategoryEmptyState.tsx
+++ b/frontend/src/pages/category/CategoryEmptyState.tsx
@@ -3,14 +3,7 @@ import styles from "./CategoryEmptyState.module.css";
 export const CategoryEmptyState = () => (
   <div className={styles.container}>
     <div className={styles.illustration}>
-      <svg
-        width="96"
-        height="96"
-        viewBox="0 0 96 96"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-      >
+      <svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         {/* Fork */}
         <line x1="26" y1="12" x2="26" y2="84" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
         <path
@@ -37,8 +30,6 @@ export const CategoryEmptyState = () => (
     </div>
 
     <h2 className={styles.title}>No recipes found</h2>
-    <p className={styles.subtitle}>
-      Try adjusting or clearing your filters to discover more delicious recipes.
-    </p>
+    <p className={styles.subtitle}>Try adjusting or clearing your filters to discover more delicious recipes.</p>
   </div>
 );

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, type ReactElement } from "reac
 import { NavLink, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { CategoryRecipesGrid } from "../../features/category-recipes-grid";
 import { CategoryFilterPanel } from "../../features/category-filters";
-import { HeroSection } from "../../shared/ui";
+import { HeroSection, EmptyState } from "../../shared/ui";
 import { useDataRecipes, useScrollToTop } from "../../shared/hooks";
 import { TestimonialsSection } from "../../shared/ui/testimonials-section";
 import styles from "./CategoryPage.module.css";
@@ -116,9 +116,7 @@ export const CategoryPage = (): ReactElement => {
                   />
                 </>
               ) : (
-                <>
-                  <div className={styles.state}>No recipes found for the selected filters.</div>
-                </>
+                <EmptyState message="No recipes found for the selected filters." />
               )}
             </>
           )}

--- a/frontend/src/pages/category/CategoryPage.tsx
+++ b/frontend/src/pages/category/CategoryPage.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, type ReactElement } from "reac
 import { NavLink, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { CategoryRecipesGrid } from "../../features/category-recipes-grid";
 import { CategoryFilterPanel } from "../../features/category-filters";
-import { HeroSection, EmptyState } from "../../shared/ui";
+import { HeroSection } from "../../shared/ui";
+import { CategoryEmptyState } from "./CategoryEmptyState";
 import { useDataRecipes, useScrollToTop } from "../../shared/hooks";
 import { TestimonialsSection } from "../../shared/ui/testimonials-section";
 import styles from "./CategoryPage.module.css";
@@ -116,7 +117,7 @@ export const CategoryPage = (): ReactElement => {
                   />
                 </>
               ) : (
-                <EmptyState message="No recipes found for the selected filters." />
+                <CategoryEmptyState />
               )}
             </>
           )}


### PR DESCRIPTION
## Summary

- Replaces the bare text fallback with a dedicated `CategoryEmptyState` component scoped to the category page
- Adds a fork-and-plate SVG illustration, a bold uppercase title ("No recipes found"), and a descriptive subtitle
- Styled with design tokens (`--fd-*`) and fully responsive (mobile / tablet breakpoints)

Closes #389

## Test plan

- [x] Apply filters on any recipe category page that yields no results — the illustrated empty state should appear
- [x] Verify the illustration, title, and subtitle are visible and centered
- [x] Check layout on mobile (375px), tablet (768px), and desktop (1440px)
- [x] Verify dark theme renders correctly (tokens adapt automatically)